### PR TITLE
set working-directory to run job

### DIFF
--- a/.github/workflows/test_changed_notebook.yml
+++ b/.github/workflows/test_changed_notebook.yml
@@ -66,10 +66,10 @@ jobs:
         echo "PATH=$PATH"
         export LD_PRELOAD=
         echo "LD_PRELOAD=$LD_PRELOAD"
-        export APPTAINER_BINDPATH=$HOME/work/example-notebooks/example-notebooks,/cvmfs
+        export APPTAINER_BINDPATH=${{ github.workspace }},/cvmfs
         echo "APPTAINER_BINDPATH=$APPTAINER_BINDPATH"
         export LMOD_CMD=/usr/share/lmod/lmod/libexec/lmod
-        export MPLCONFIGDIR=$HOME/work/example-notebooks/example-notebooks/matplotlib-mpldir
+        export MPLCONFIGDIR=${{ github.workspace }}/matplotlib-mpldir
         export MODULEPATH=$(find /cvmfs/neurodesk.ardc.edu.au/neurodesk-modules/ -maxdepth 1 -mindepth 1 -type d -exec realpath {} \; | tr '\n' ':')
         echo "MODULEPATH=$MODULEPATH"
         jb build .

--- a/.github/workflows/test_changed_notebook.yml
+++ b/.github/workflows/test_changed_notebook.yml
@@ -38,6 +38,7 @@ jobs:
   test-notebooks:
     needs: select-runner
     runs-on: ${{ needs.select-runner.outputs.runner }}
+    
     # strategy:
     #   fail-fast: false
     #   matrix:
@@ -57,7 +58,10 @@ jobs:
 
     - name: Run qsmxt_example
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
+        echo ${{ github.workspace }}
+        echo $GITHUB_WORKSPACE
         export PATH=$HOME/.local/bin:$PATH
         echo "PATH=$PATH"
         export LD_PRELOAD=


### PR DESCRIPTION
nipype output paths are resolved relative to the runner's workspace directory, which is _work dir by default causing issue for the workflow to find files