### PR TITLE
Fix: Split workflow to avoid multiple pushes to gh-pages

### DIFF
--- a/.github/scripts/add-doi-button.js
+++ b/.github/scripts/add-doi-button.js
@@ -23,18 +23,31 @@ function injectDoiLink(doi, htmlFilePath) {
     process.exit(1);
   }
 
-  // Create the <a> element styled as a button
-  const link = document.createElement('a');
-  link.textContent = `${doi}`;
-  link.href = `${doi}`;
-  link.target = '_blank';
-  link.rel = 'noopener noreferrer';
-  link.className = 'btn btn-sm nav-link pst-navbar-icon theme-switch-button';
+  const doiHref = `${doi}`;
+    // Try to find an existing DOI button based on known pattern
+  let existingButton = Array.from(container.querySelectorAll('a')).find(a => 
+    a.href.includes('doi.org')
+  );
 
-  container.prepend(link);
+  if (existingButton) {
+    // Update existing DOI button
+    existingButton.href = doiHref;
+    existingButton.textContent = `${doi}`;
+    console.log(`🔄 Updated existing DOI button with: ${doiHref}`);
+  } else {
+    // Create the <a> element styled as a button
+    const link = document.createElement('a');
+    link.textContent = `${doi}`;
+    link.href = `${doi}`;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.className = 'btn btn-sm nav-link pst-navbar-icon theme-switch-button';
 
-  fs.writeFileSync(htmlFilePath, dom.serialize());
-  console.log(`DOI link added to ${htmlFilePath}`);
+    container.prepend(link);
+
+    fs.writeFileSync(htmlFilePath, dom.serialize());
+    console.log(`DOI link added to ${htmlFilePath}`);
+  }
 }
 
 // --- CLI Entry Point ---

--- a/.github/scripts/get-updated-notebooks.py
+++ b/.github/scripts/get-updated-notebooks.py
@@ -76,8 +76,8 @@ def list_updated_notebooks(repo_checksums, zenodo_checksums):
     """
     updated_notebooks = []
     for notebook, checksum in repo_checksums.items():
-        if checksum not in zenodo_checksums:
-            updated_notebooks.append(notebook)
+        # if checksum not in zenodo_checksums:
+        updated_notebooks.append(notebook)
     return updated_notebooks
     
 if __name__ == "__main__":

--- a/.github/scripts/get-updated-notebooks.py
+++ b/.github/scripts/get-updated-notebooks.py
@@ -76,8 +76,8 @@ def list_updated_notebooks(repo_checksums, zenodo_checksums):
     """
     updated_notebooks = []
     for notebook, checksum in repo_checksums.items():
-        # if checksum not in zenodo_checksums:
-        updated_notebooks.append(notebook)
+        if checksum not in zenodo_checksums:
+            updated_notebooks.append(notebook)
     return updated_notebooks
     
 if __name__ == "__main__":

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -63,26 +63,35 @@ jobs:
           - name: Upload updated notebook
             uses: actions/upload-artifact@v4
             with:
-              name: notebook-doi
+              name: ${{ env.NOTEBOOK_NAME }}
               path: ${{ env.NOTEBOOK_NAME }}.txt
 
 
     add-doi-button:
-      needs: publish-doi
+      needs: [get-updated-notebooks, publish-doi]
       runs-on: ubuntu-22.04
       strategy:
           fail-fast: false
           matrix:
             notebooks: ${{ fromJSON(needs.get-updated-notebooks.outputs.updated_notebooks_list) }}
+      outputs:
+          notebook_name: ${{ steps.get_notebook_name.outputs.NOTEBOOK_NAME }}
       steps:
           - name: Checkout gh-pages branch
             uses: actions/checkout@v4
             with:
                 ref: gh-pages
                 fetch-depth: 0
+          - name: Get notebook name
+            id: get_notebook_name
+            run: |
+              NOTEBOOK_NAME=$(echo "${{ matrix.notebooks }}" | cut -d'/' -f3 | cut -d'.' -f1)
+              echo "NOTEBOOK_NAME=$NOTEBOOK_NAME" >> $GITHUB_ENV
+              echo "NOTEBOOK_NAME=${NOTEBOOK_NAME}" >> $GITHUB_OUTPUT
           - name: Download all updated notebooks
             uses: actions/download-artifact@v4
             with:
+              name: ${{ env.NOTEBOOK_NAME }}
               path: notebook-doi
           - name: Install node
             uses: actions/setup-node@v4
@@ -109,8 +118,8 @@ jobs:
           - name: Upload updated notebook
             uses: actions/upload-artifact@v4
             with:
-              name: updated-notebook
-              path: ${{ env.HTML_PATH }}
+              name: updated-notebook-${{ env.NOTEBOOK_NAME }}
+              path: ${{ github.workspace }}/*/${{ env.HTML_PATH }}
 
     publish-pages:
       needs: add-doi-button
@@ -126,7 +135,9 @@ jobs:
           uses: actions/download-artifact@v4
           with:
             path: updated-notebooks
-
+            merge-multiple: true
+        - name: Display structure of downloaded files
+          run: ls -R
         - name: Move updated notebooks to correct locations
           run: |
             find updated-notebooks -type f -name '*.html' -exec cp --parents {} . \;

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -86,12 +86,36 @@ jobs:
               HTML_PATH="${NOTEBOOK_PARENT}/${NOTEBOOK_NAME}.html"
               echo "HTML_PATH: $HTML_PATH"
               node add-doi-button.js "${DOI_URL}" "${HTML_PATH}"
-
-          - name: Push to GitHub Pages
-            uses: peaceiris/actions-gh-pages@v4.0.0
+          - name: Upload updated notebook
+            uses: actions/upload-artifact@v4
             with:
-              github_token: ${{ secrets.GITHUB_TOKEN }}
-              publish_dir: ./
-              publish_branch: gh-pages
-              keep_files: true
-              cname: www.neurodesk.org
+              name: updated-notebook-${{ matrix.notebooks }}
+              path: ${{ env.HTML_PATH }}
+
+    publish-pages:
+      needs: publish-doi
+      runs-on: ubuntu-22.04
+      steps:
+        - name: Checkout gh-pages branch
+          uses: actions/checkout@v4
+          with:
+            ref: gh-pages
+            fetch-depth: 0
+
+        - name: Download all updated notebooks
+          uses: actions/download-artifact@v4
+          with:
+            path: updated-notebooks
+
+        - name: Move updated notebooks to correct locations
+          run: |
+            find updated-notebooks -type f -name '*.html' -exec cp --parents {} . \;
+
+        - name: Push to GitHub Pages
+          uses: peaceiris/actions-gh-pages@v4.0.0
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: ./
+            publish_branch: gh-pages
+            keep_files: true
+            cname: www.neurodesk.org

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -113,7 +113,7 @@ jobs:
               path: ${{ env.HTML_PATH }}
 
     publish-pages:
-      needs: publish-doi
+      needs: add-doi-button
       runs-on: ubuntu-22.04
       steps:
         - name: Checkout gh-pages branch

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -140,7 +140,8 @@ jobs:
           run: ls -R
         - name: Move updated notebooks to correct locations
           run: |
-            find updated-notebooks -type f -name '*.html' -exec cp --parents {} . \;
+            cd updated-notebooks
+            find . -type f -name '*.html' -exec cp --parents {} .. \;
 
         - name: Push to GitHub Pages
           uses: peaceiris/actions-gh-pages@v4.0.0

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -119,7 +119,7 @@ jobs:
             uses: actions/upload-artifact@v4
             with:
               name: updated-notebook-${{ env.NOTEBOOK_NAME }}
-              path: ${{ github.workspace }}/*/${{ env.HTML_PATH }}
+              path: ${{ github.workspace }}/*${{ env.HTML_PATH }}
 
     publish-pages:
       needs: add-doi-button

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -64,7 +64,7 @@ jobs:
             uses: actions/upload-artifact@v4
             with:
               name: notebook-doi
-              path: ${NOTEBOOK_NAME}.txt
+              path: ${{ env.NOTEBOOK_NAME }}.txt
 
 
     add-doi-button:

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -85,6 +85,7 @@ jobs:
               echo "NOTEBOOK_PARENT: $NOTEBOOK_PARENT"
               HTML_PATH="${NOTEBOOK_PARENT}/${NOTEBOOK_NAME}.html"
               echo "HTML_PATH: $HTML_PATH"
+              echo "HTML_PATH=${HTML_PATH}" >> $GITHUB_ENV
               node add-doi-button.js "${DOI_URL}" "${HTML_PATH}"
           - name: Upload updated notebook
             uses: actions/upload-artifact@v4

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -59,14 +59,31 @@ jobs:
               sed -i "s/^[[:space:]]*license = get_license(args.container_name, args.gh_token)/    license = 'mit'/" .github/scripts/publish-doi.py
               export DOI_URL=$(python3 .github/scripts/publish-doi.py --container_filepath="https://raw.githubusercontent.com/Neurodesk/example-notebooks/refs/heads/main/${{ matrix.notebooks }}" --container_name=${NOTEBOOK_BUILDDATE} --zenodo_token=${{ secrets.ZENODO_TOKEN }} --gh_token=${{ secrets.GITHUB_TOKEN }} | tail -n 1)
               echo "DOI_URL: $DOI_URL"
-              echo "DOI_URL=${DOI_URL}" >> $GITHUB_ENV
+              echo "${DOI_URL}" >> ${NOTEBOOK_NAME}.txt
+          - name: Upload updated notebook
+            uses: actions/upload-artifact@v4
+            with:
+              name: notebook-doi
+              path: ${NOTEBOOK_NAME}.txt
 
+
+    add-doi-button:
+      needs: publish-doi
+      runs-on: ubuntu-22.04
+      strategy:
+          fail-fast: false
+          matrix:
+            notebooks: ${{ fromJSON(needs.get-updated-notebooks.outputs.updated_notebooks_list) }}
+      steps:
           - name: Checkout gh-pages branch
             uses: actions/checkout@v4
             with:
                 ref: gh-pages
                 fetch-depth: 0
-                
+          - name: Download all updated notebooks
+            uses: actions/download-artifact@v4
+            with:
+              path: notebook-doi
           - name: Install node
             uses: actions/setup-node@v4
             with:
@@ -86,11 +103,13 @@ jobs:
               HTML_PATH="${NOTEBOOK_PARENT}/${NOTEBOOK_NAME}.html"
               echo "HTML_PATH: $HTML_PATH"
               echo "HTML_PATH=${HTML_PATH}" >> $GITHUB_ENV
+              DOI_URL=$(cat notebook-doi/${NOTEBOOK_NAME}.txt)
+              echo "DOI_URL: $DOI_URL"
               node add-doi-button.js "${DOI_URL}" "${HTML_PATH}"
           - name: Upload updated notebook
             uses: actions/upload-artifact@v4
             with:
-              name: updated-notebook-${{ matrix.notebooks }}
+              name: updated-notebook
               path: ${{ env.HTML_PATH }}
 
     publish-pages:

--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -44,7 +44,7 @@ jobs:
           - name: Install dependencies
             run: |
               python -m pip install --upgrade pip
-              pip install requests
+              pip install requests pyyaml>=6.0.2
           - name : Publish singularity container files in nectar cloud to Zenodo
             id: publish_doi
             shell: bash

--- a/books/_static/algolia.css
+++ b/books/_static/algolia.css
@@ -1,18 +1,8 @@
 /* Hide search button from article-header-buttons
 Removing `search_bar_text` from 
 `html_theme_options` in conf.py doesn't work */
-.search-button-field {
+.btn.search-button-field.search-button__button {
     display: none;
-}
-
-@media (min-width: 992px) {
-  .search-button {
-    display: none !important;
-  }
-
-  .search-button-field {
-    display: flex;
-  }
 }
 
 /* Hide the search wrapper window when hitting Ctrl+K */

--- a/books/_static/algolia.css
+++ b/books/_static/algolia.css
@@ -1,8 +1,18 @@
 /* Hide search button from article-header-buttons
 Removing `search_bar_text` from 
 `html_theme_options` in conf.py doesn't work */
-.btn.search-button-field.search-button__button {
+.search-button-field {
     display: none;
+}
+
+@media (min-width: 992px) {
+  .search-button {
+    display: none !important;
+  }
+
+  .search-button-field {
+    display: flex;
+  }
 }
 
 /* Hide the search wrapper window when hitting Ctrl+K */

--- a/books/_static/algolia.css
+++ b/books/_static/algolia.css
@@ -1,7 +1,7 @@
 /* Hide search button from article-header-buttons
 Removing `search_bar_text` from 
 `html_theme_options` in conf.py doesn't work */
-.search-button__button {
+.btn.search-button-field.search-button__button {
     display: none;
 }
 

--- a/books/_static/algolia.css
+++ b/books/_static/algolia.css
@@ -1,7 +1,7 @@
 /* Hide search button from article-header-buttons
 Removing `search_bar_text` from 
 `html_theme_options` in conf.py doesn't work */
-.search-button {
+.search-button__button {
     display: none;
 }
 

--- a/books/workflows/nipype_full.ipynb
+++ b/books/workflows/nipype_full.ipynb
@@ -264,7 +264,7 @@
    "source": [
     "## 2. Nipype in Jupyter Notebooks on Neurodesk\n",
     "\n",
-    "<img src=\"https://www.neurodesk.org/static/logos/neurodesk.org_horizontal.png\" style=\"float: right; margin: 0 auto; padding: 5px;\" width=\"15%\" height=\"15%\">\n",
+    "<img src=\"https://www.neurodesk.org/static/logos/neurodesk.org_horizontal.png\" style=\"float: right; margin: 0 auto; padding: 5px;\" width=\"25%\" height=\"25%\">\n",
     "\n",
     "\n",
     "Neurodesk project enables the use of all neuroimaging applications inside computational notebooks\n"


### PR DESCRIPTION
- Overwrite DOI button if it exists
- Split workflow into separate jobs
- Upload doi and html to artifacts
- Remove the default search bar, only use Agolia one